### PR TITLE
[KMD] Fix URL scheme to avoid problem if breadwallet is installed fro…

### DIFF
--- a/BreadWallet/Info.plist
+++ b/BreadWallet/Info.plist
@@ -72,7 +72,7 @@
 			<string>com.satindergrewal.agamawalletkmd</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>bread</string>
+				<string>komodowallet</string>
 			</array>
 		</dict>
 		<dict>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Simplicity is **breadwallet**'s core design principle. A simple backup phrase is
 **breadwallet** supports the [x-callback-url](http://x-callback-url.com) specification with the following URLs:
 
 ```
-bread://x-callback-url/address?x-success=myscheme://myaction
+komodowallet://x-callback-url/address?x-success=myscheme://myaction
 ```
 
 This will callback with the current wallet receive address: `myscheme://myaction?address=1XXXX`
@@ -49,7 +49,7 @@ This will callback with the current wallet receive address: `myscheme://myaction
 The following will ask the user to authorize copying a list of their wallet addresses to the clipboard before calling back:
 
 ```
-bread://x-callback-url/addresslist?x-success=myscheme://myaction
+komodowallet://x-callback-url/addresslist?x-success=myscheme://myaction
 ```
 
 ### WARNING:

--- a/TodayExtension/BRTodayViewController.m
+++ b/TodayExtension/BRTodayViewController.m
@@ -29,8 +29,8 @@
 #import "UIImage+Utils.h"
 #import <NotificationCenter/NotificationCenter.h>
 
-#define SCAN_URL @"bread://x-callback-url/scanqr"
-#define OPEN_URL @"bread://"
+#define SCAN_URL @"komodowallet://x-callback-url/scanqr"
+#define OPEN_URL @"komodowallet://"
 
 @interface BRTodayViewController () <NCWidgetProviding>
 


### PR DESCRIPTION
In case of user have already BreadWallet and KomodoWallet on his smartphone. Current URL scheme will not work (two apps offer same URL scheme).

So instead of using bread:// we will use komodowallet://